### PR TITLE
Use codegangsta/gin instead of go-reload + smaller Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@ language: go
 
 go:
   - 1.4.1
-  
+
+addons:
+  postgresql: "9.3"
+
 install:
   - go install -race std
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/tools/godep
+  - go get bitbucket.org/liamstask/goose/cmd/goose
   - export PATH=$PATH:$HOME/gopath/bin
+
+before_script:
+  - psql -c 'create database firesize_test;' -U postgres
+  - DATABASE_URL=postgres://localhost/firesize_test?sslmode=disable goose up
 
 script:
   - godep go test -race -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM golang:latest
+FROM google/golang:latest
 MAINTAINER Dave Newman <dave@assembly.com> (@whatupdave)
 
-ADD . /go/src/github.com/asm-products/firesize
+ADD . /gopath/src/github.com/asm-products/firesize
 RUN go get -u github.com/tools/godep \
               bitbucket.org/liamstask/goose/cmd/goose \
               github.com/codegangsta/gin
 
-RUN apt-get update
-RUN apt-get install -y git nodejs imagemagick npm inotify-tools
+RUN apt-get install --no-install-recommends -y -q imagemagick
 
-RUN curl https://raw.githubusercontent.com/alexedwards/go-reload/master/go-reload \
-            -o /usr/local/bin/go-reload && \
-    chmod +x /usr/local/bin/go-reload
-
-WORKDIR /go/src/github.com/asm-products/firesize
+WORKDIR /gopath/src/github.com/asm-products/firesize
 
 RUN godep restore

--- a/fig.yml
+++ b/fig.yml
@@ -1,24 +1,21 @@
 web:
   build: .
-  command: go-reload server.go
+  command: gin run go run server.go
   ports:
     - "3000:3000"
   volumes:
     - .:/go/src/github.com/asm-products/firesize
   links:
     - db
-
   environment:
-    - DATABASE_URL=postgres://postgres@db/firesize_development?sslmode=disable
+    - DATABASE_URL=postgres://postgres@db/postgres?sslmode=disable
 
 db:
-  image: postgres:latest
+  image: kiasaki/alpine-postgres:latest
   ports:
     - "5432"
 
 webpack:
-  image: node:latest
-  command: ./webpack.sh
-  working_dir: /app
+  build: scripts/webpack-docker
   volumes:
     - .:/app

--- a/scripts/webpack-docker/Dockerfile
+++ b/scripts/webpack-docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM gliderlabs/alpine:3.1
+
+RUN apk-install git nodejs
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/webpack.sh"]

--- a/webpack.sh
+++ b/webpack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 PATH=$(npm bin):$PATH


### PR DESCRIPTION
Bounty: https://assembly.com/firesize/bounties/44

While setting my environment I noticed the nodejs and postgresql docker images were really fat so I went and used really minimal base images for them

Works as a charm!