### PR TITLE
Add Makefile for common development commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+setup:
+	go get bitbucket.org/liamstask/goose/cmd/goose
+	[[ -f ".env" ]] || cp .env.sample .env
+
+run:
+	godep go run server.go
+
+watch:
+	gin godep go run server.go
+
+watch_assets:
+	. webpack.sh
+
+migrate:
+	export $(cat .env | xargs) > /dev/null && goose up
+
+migrate_test:
+	export $(cat .env | sed 's/_development/_test/' | xargs) > /dev/null && goose up
+
+test:
+	godep go test -race -v ./...


### PR DESCRIPTION
I find myself using a local postgres, golang, nodejs setup I use everyday anyway (i.e. not using fig or Docker)

Felt I was `cat`ing files here and there used in the docker setup or CI just to remember the commands used

So, decided on grouping them all in a easy to use Makefile