### PR TITLE
Add python dep to the webapp's Dockerfile.

### DIFF
--- a/scripts/webpack-docker/Dockerfile
+++ b/scripts/webpack-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM gliderlabs/alpine:3.1
 
-RUN apk-install git nodejs
+RUN apk-install git nodejs python
 
 WORKDIR /app
 


### PR DESCRIPTION
node-gyp  is used by the contextify node.js module and has a dependency on python 2.7