### PR TITLE
Use gorp.v1

### DIFF
--- a/models/db.go
+++ b/models/db.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/go-gorp/gorp"
+	"gopkg.in/gorp.v1"
 	_ "github.com/lib/pq"
 )
 


### PR DESCRIPTION
I see that you are importing `gorp` from `github.com/go-gorp/gorp`.
This is the unstable "bleeding edge" version. We are working on breaking changes, it is likely that your program will fail to compile unless you update your code to reflect the changes.

I have not tested this change, but opened a PR anyway since issues are disabled.

Please use `gopkg.in/gorp.v1` as import path, it provides the last stable gorp v1 release and will not break (unless a breaking change is required to fix a security issue).

When the changes to the master branch are complete, v2 will be released. See go-gorp/gorp#270 for more information.
Thanks.
